### PR TITLE
Update property value regex to allow single quotes

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -28,7 +28,7 @@ const getCSSCustomProp = propKey => {
   let response = getComputedStyle(document.documentElement).getPropertyValue(propKey);
 
   if (response.length) {
-    response = response.replace(/\"/g, '').trim();
+    response = response.replace(/[\"\']/g, '').trim();
   }
 
   return response;


### PR DESCRIPTION
This is an attempt to fix the #2 bug. It is caused by the method `getCSSCustomProp` returning `'light'` on Windows/FF78 while it should return `light` (without single quotes).

I enhanced the regex by also replacing single quotes (from `/\"/g` to `/[\"\']/g`).

See this demonstration in the dev console below:

![grafik](https://user-images.githubusercontent.com/28510368/84539591-04c15c00-acf4-11ea-94b6-91d65a37cafa.png)

I assume the bug is caused by different quote behavior in the CSS engines of Firefox and Chrome (which you likely developed it in). Another way to fix this could be to use the `substring` method on the string to remove the first and last character (or regex to remove these characters if they are not alphanumerical or a minus) but this may not work for numerical values, so I wouldn't add unnecessary complexity. 😅 